### PR TITLE
Url generation is fixed in lumen console

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,14 +46,6 @@ To use the shell:
 
 `php artisan tinker`
 
-# Known Issues
-
-Lumen UrlGenerator do not generate correctly urls for non-browser requests, if you
-want to generate url on console commands or tests, I recommend you to install that 
-package to fix it:
-
-- [vluzrmos/lumen-url-host](https://github.com/vluzrmos/lumen-url-host).
-
 # Credits
 
 That package is a partial modification


### PR DESCRIPTION
Remove known issues from readme, because the issue is obsolete.
https://github.com/laravel/lumen-framework/pull/739

Example:
```
Psy Shell v0.8.18 (PHP 7.2.6 — cli) by Justin Hileman
New version is available (current: v0.8.18, latest: v0.9.4)
>>> url('/')
=> "http://localhost"
```

Before the fix the was no hostname or scheme in the generated url.